### PR TITLE
IpService now resets failed attempts after 24 hours

### DIFF
--- a/api/models/VerifyApostilleIpLog.js
+++ b/api/models/VerifyApostilleIpLog.js
@@ -12,6 +12,10 @@ module.exports = {
             type: 'number',
             columnType: 'integer'
         },
+        FirstFailedAttemptAt: {
+            type: 'string',
+            columnType: 'varchar(27)'
+        },
         BlockedAt: {
             type: 'string',
             columnType: 'varchar(27)'

--- a/api/services/IpService.js
+++ b/api/services/IpService.js
@@ -2,9 +2,11 @@ const moment = require("moment");
 
 var IpService = {
 
+    /**
+     * Delete rows when a day has passed since blocked, 
+     * or when a day has passed since first block and haven't been blocked
+     */
     unblockIpsIfDayPassed: async function() {
-        // Delete rows when a day has passed since blocked, 
-        // or when a day has passed since first block and haven't been blocked
         await VerifyApostilleIpLog.destroy({
             where: {
                 or: [

--- a/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
+++ b/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS public."VerifyApostilleIpLog"
 (
     "Ip" inet NOT NULL,
     "FailedAttempts" integer,
+    "FirstFailedAttemptAt" varchar(27),
     "BlockedAt" varchar(27),
     CONSTRAINT "VerifyApostilleIpLog_pkey" PRIMARY KEY ("Ip")
 )

--- a/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
+++ b/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
@@ -7,5 +7,7 @@ CREATE TABLE IF NOT EXISTS public."VerifyApostilleIpLog"
 );
 
 -- Without FirstFailedAttemptAt, existing rows will not update this column, so we must drop existing rows
+BEGIN;
 TRUNCATE "VerifyApostilleIpLog";
 ALTER TABLE "VerifyApostilleIpLog" ADD COLUMN "FirstFailedAttemptAt" varchar(27);
+COMMIT;

--- a/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
+++ b/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
@@ -2,7 +2,10 @@ CREATE TABLE IF NOT EXISTS public."VerifyApostilleIpLog"
 (
     "Ip" inet NOT NULL,
     "FailedAttempts" integer,
-    "FirstFailedAttemptAt" varchar(27),
     "BlockedAt" varchar(27),
     CONSTRAINT "VerifyApostilleIpLog_pkey" PRIMARY KEY ("Ip")
 )
+
+-- Without FirstFailedAttemptAt, existing rows will not update this column, so we must drop existing rows
+delete from "VerifyApostilleIpLog";
+ALTER TABLE "VerifyApostilleIpLog" ADD COLUMN "FirstFailedAttemptAt" varchar(27);

--- a/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
+++ b/database_change_log/FCDO-513-VerifyApostilleIpLog.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS public."VerifyApostilleIpLog"
     "FailedAttempts" integer,
     "BlockedAt" varchar(27),
     CONSTRAINT "VerifyApostilleIpLog_pkey" PRIMARY KEY ("Ip")
-)
+);
 
 -- Without FirstFailedAttemptAt, existing rows will not update this column, so we must drop existing rows
-delete from "VerifyApostilleIpLog";
+TRUNCATE "VerifyApostilleIpLog";
 ALTER TABLE "VerifyApostilleIpLog" ADD COLUMN "FirstFailedAttemptAt" varchar(27);


### PR DESCRIPTION
Prevents issue where a user may fail once a day over 10 days, 10 weeks, 10 months..etc, and then be randomly blocked on the 10th failed attempt.

Logic:

1. If not blocked, check if been 24 hours since first failed attempt and if more than 24 hours, clear
2. If blocked, check if been 24 hours since last failed attempt and if more than 24 hours, clear

Essentially, you are allowed 10 attempts per 24 hours now.

Note: Existing rows would need to be deleted for this change, since they will not have the new `FirstFailedAttemptAt` column, and it won't work properly.